### PR TITLE
Fix updater for Windows hosts

### DIFF
--- a/properties.xml
+++ b/properties.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <properties>
 	<version>1.1.1</version>
-	<zipUrl>http://updates.scify.org/talk-n-play/talkandplay.zip</zipUrl>
 	<versionFileUrl>http://updates.scify.org/talk-n-play/properties.xml</versionFileUrl>
-	<zipFile>talkandplay.zip</zipFile>
 	<propertiesFile>properties.xml</propertiesFile>
+	<zipUrl>http://updates.scify.org/talk-n-play/talkandplay.zip</zipUrl>
+	<zipUrlWindows>http://updates.scify.org/talk-n-play/talkandplay_windows.zip</zipUrlWindows>
+	<zipFile>talkandplay.zip</zipFile>
+	<zipFileWindows>talkandplay_windows.zip</zipFileWindows>
 </properties>

--- a/src/main/java/org/scify/talkandplay/utils/Properties.java
+++ b/src/main/java/org/scify/talkandplay/utils/Properties.java
@@ -16,6 +16,7 @@
 package org.scify.talkandplay.utils;
 
 import java.io.File;
+import java.net.URLDecoder;
 import org.jdom.Document;
 import org.jdom.Element;
 import org.jdom.input.SAXBuilder;
@@ -42,16 +43,14 @@ public class Properties {
 
     public Properties() {
         try {
-
-            applicationFolder = (new File(Properties.class
+            String encodedApplicationFolder = (new File(Properties.class
                     .getProtectionDomain()
                     .getCodeSource()
                     .getLocation()
                     .getPath())).getParentFile().getAbsolutePath();
+            applicationFolder = URLDecoder.decode(encodedApplicationFolder, "UTF-8");
 
-
-            String absolutePath = this.applicationFolder+ File.separator + "properties.xml";
-            File file = new File(absolutePath);
+            File file = new File(applicationFolder, "properties.xml");
             if (!file.exists()) {
                 file = new File("properties.xml");
             }

--- a/src/main/java/org/scify/talkandplay/utils/Properties.java
+++ b/src/main/java/org/scify/talkandplay/utils/Properties.java
@@ -69,10 +69,16 @@ public class Properties {
 
         setVersion(properties.getChildText("version"));
         setVersionFileUrl(properties.getChildText("versionFileUrl"));
-        setZipUrl(properties.getChildText("zipUrl"));
         setTmpFolder(properties.getChildText("tmpFolder"));
-        setZipFile(properties.getChildText("zipFile"));
         setPropertiesFile(properties.getChildText("propertiesFile"));
+
+        if (System.getProperty("os.name").startsWith("Windows")) {
+            setZipUrl(properties.getChildText("zipUrlWindows"));
+            setZipFile(properties.getChildText("zipFileWindows"));
+        } else {
+            setZipUrl(properties.getChildText("zipUrl"));
+            setZipFile(properties.getChildText("zipFile"));
+        }
     }
 
     public String getVersion() {


### PR DESCRIPTION
Merging this PR and following the above notes, _Talk And Play_ will be able to auto-update itself in windows machines. 

- Please use the following configurations:
  - Launch4J 
    - https://gist.github.com/atzorvas/3afac730c6d9bf4c16514e1915408c80#file-talk_n_play_conf_atzorvas-xml
  - Inno Setup
    - https://gist.github.com/atzorvas/3afac730c6d9bf4c16514e1915408c80#file-talk-n-play-latest-iss
- The remote host with the zipFiles should contain the following:
![fix_windows_updater](https://cloud.githubusercontent.com/assets/527550/20769787/f930d1b4-b74b-11e6-92d1-ce7003a5275a.png)
